### PR TITLE
Ignore x path

### DIFF
--- a/XmlDiffLib.Tests/UnitTest1.cs
+++ b/XmlDiffLib.Tests/UnitTest1.cs
@@ -37,5 +37,52 @@ namespace XmlDiffLib.Tests
       Assert.AreEqual(diff.DiffNodeList.Count, 2);
       Assert.IsTrue(diff.DiffNodeList[1].Description.Contains("CompanyID"));
     }
+
+    /// <summary>
+    /// GIVEN   an xml structure with a node to be ignored
+    /// WHEN    the xpath is specified that needs to be ignored
+    /// THEN    comparedocument should return true
+    /// </summary>
+    [TestMethod]
+    public void TestXmlIgnoreXPathWithValue()
+    {
+        // Arrange
+        string fromXml = "<Root><Node><SubNode>Foo</SubNode><IgnoreNode>Bar</IgnoreNode></Node><Node><SubNode><Element>Foo</Element></SubNode></Node></Root>";
+        string toXml = "<Root><Node><SubNode>Foo</SubNode></Node><Node><SubNode><Element>Foo</Element></SubNode></Node></Root>";
+
+        XmlDiff xmlDiff = new XmlDiff(fromXml, toXml);
+
+        XmlDiffOptions xmlDiffOptions = new XmlDiffOptions();
+        xmlDiffOptions.IgnoreXPaths.Add("Root/Node/IgnoreNode");
+
+        // Act
+        bool isSame = xmlDiff.CompareDocuments(xmlDiffOptions);
+
+        // Assert
+        Assert.IsTrue(isSame);
+    }
+
+    /// <summary>
+    /// GIVEN   an xml structure with a node missing
+    /// WHEN    no xpath to be ignored is not provided
+    /// THEN    comparedocument should return false
+    /// </summary>
+    [TestMethod]
+    public void TestXmlIgnoreXPathWithoutValue()
+    {
+        // Arrange
+        string fromXml = "<Root><Node><SubNode>Foo</SubNode><IgnoreNode>Bar</IgnoreNode></Node><Node><SubNode><Element>Foo</Element></SubNode></Node></Root>";
+        string toXml = "<Root><Node><SubNode>Foo</SubNode></Node><Node><SubNode><Element>Foo</Element></SubNode></Node></Root>";
+
+        XmlDiff xmlDiff = new XmlDiff(fromXml, toXml);
+
+        XmlDiffOptions xmlDiffOptions = new XmlDiffOptions();
+
+        // Act
+        bool isSame = xmlDiff.CompareDocuments(xmlDiffOptions);
+
+        // Assert
+        Assert.IsFalse(isSame);
+    }
   }
 }

--- a/XmlDiffLib/XmlDiff.cs
+++ b/XmlDiffLib/XmlDiff.cs
@@ -35,6 +35,7 @@ namespace XmlDiffLib
     public bool IgnoreChildOrder { get; set; }
     public bool IgnoreAttributes { get; set; }
     public HashSet<XPathNodeType> IgnoreNodes { get; set; }
+    public HashSet<string> IgnoreXPaths { get; set; }
     public bool IgnoreNamespace { get; set; }
     public bool IgnorePrefix { get; set; }
     public bool TrimWhitespace { get; set; }
@@ -59,6 +60,7 @@ namespace XmlDiffLib
       MatchValueTypes = true;
       TwoWayMatch = false;
       IgnoreNodes = new HashSet<XPathNodeType>();
+      IgnoreXPaths = new HashSet<string>();
       IgnoreTextTypes = new HashSet<IgnoreTextNodeOptions>();
       MaxAttributesToDisplay = -1;
     }
@@ -275,8 +277,11 @@ namespace XmlDiffLib
 
         do
         {
-          if (options.IgnoreNodes.Contains(xFrom.NodeType))
-            continue;
+          if (options.IgnoreNodes.Contains(xFrom.NodeType) ||
+                            options.IgnoreXPaths.Contains(GetXPath(xFrom, false)))
+            {
+                continue;
+            }
 
           XmlDiffNode nodeInfo;
           if (!options.IgnoreChildOrder)
@@ -495,7 +500,7 @@ namespace XmlDiffLib
       return true;
     }
 
-    private string GetXPath(XPathNavigator nav)
+    private string GetXPath(XPathNavigator nav, bool addNodePosition = true)
     {
       Func<XPathNavigator, string> addAttrib =
         (node) =>
@@ -525,7 +530,7 @@ namespace XmlDiffLib
         if (string.IsNullOrEmpty(xNav.LocalName))
           continue;
         string tempLabel = xNav.LocalName + addAttrib(xNav);
-        tempLabel += "[" + GetSiblingPosition(xNav) + "]";
+        if (addNodePosition) { tempLabel += "[" + GetSiblingPosition(xNav) + "]"; }
         tempLabel += "/";
 
         result.Insert(0, tempLabel);


### PR DESCRIPTION
Added functionality to specify an XPath(s) to be ignored when two XML Documents are being compared.

XPath is inputted as a string into a Hashset